### PR TITLE
Cannot remove deleted un-versioned DataObject from Elastic index

### DIFF
--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -81,12 +81,12 @@ class DataObjectDocument implements
     /**
      * This is the identifier (id) used in the search engine and based on the class and object id.
      */
-    private string $identifier = '';
+    private ?string $identifier = null;
 
     /**
      * This is the classname of the data object, populated for the purpose of handling un-versioned deletions
      */
-    private string $className = '';
+    private ?string $className = null;
 
     /**
      * @var PageCrawler|null

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -693,7 +693,7 @@ class DataObjectDocument implements
 
                 $currentDataObject = $this->getDataObject();
 
-                $liveDataObject = DataObject::get($currentDataObject->ClassName)->byID($currentDataObject->ID);
+                $liveDataObject = $currentDataObject ? DataObject::get($currentDataObject->ClassName)->byID($currentDataObject->ID) : null;
 
                 if (!$liveDataObject) {
                     // unlikely case as indexer calls 'shouldIndex' immediately prior to this

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -647,6 +647,14 @@ class DataObjectDocument implements
     {
         $dataObject = DataObject::get_by_id($data['className'], $data['id']);
 
+        if (!$dataObject && DataObject::has_extension($data['className'], Versioned::class) && $data['fallback']) {
+            // get the latest version - usually this is an object that has been deleted
+            $dataObject = Versioned::get_latest_version(
+                $data['className'],
+                $data['id']
+            );
+        }
+
         // If the data object no longer exists, then we can pass back the identifier
         // and class name - for example, when handling the deletion of un-versioned data objects
         if (!$dataObject) {
@@ -656,18 +664,6 @@ class DataObjectDocument implements
             $this->setDependencies();
 
             return;
-        }
-
-        if (!$dataObject && DataObject::has_extension($data['className'], Versioned::class) && $data['fallback']) {
-            // get the latest version - usually this is an object that has been deleted
-            $dataObject = Versioned::get_latest_version(
-                $data['className'],
-                $data['id']
-            );
-        }
-
-        if (!$dataObject) {
-            throw new Exception(sprintf('DataObject %s : %s does not exist', $data['className'], $data['id']));
         }
 
         $this->setDataObject($dataObject);

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -404,7 +404,16 @@ class DataObjectDocument implements
             return is_subclass_of($class, DataObject::class);
         });
         $ownedDataObject = $this->getDataObject();
+
         $docs = [];
+
+        // make sure we have a data object
+        // if not (it might have been deleted), then return empty dependency
+        // documents with the assumption that if there are any dependencies
+        // they will be handled separately
+        if (!$ownedDataObject) {
+            return $docs;
+        }
 
         foreach ($dataObjectClasses as $class) {
             // Start with a singleton to look at the model first, then get real records if needed

--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -88,7 +88,9 @@ class DataObjectFetcher implements DocumentFetcherInterface
     {
         $list = DataList::create($this->dataObjectClass);
 
-        return $list->limit($limit, $offset);
+        return $list
+            ->sort('ID', 'ASC')
+            ->limit($limit, $offset);
     }
 
 }

--- a/src/Interfaces/DataObjectDocumentInterface.php
+++ b/src/Interfaces/DataObjectDocumentInterface.php
@@ -10,6 +10,6 @@ use SilverStripe\ORM\DataObject;
 interface DataObjectDocumentInterface
 {
 
-    public function getDataObject(): DataObject;
+    public function getDataObject(): ?DataObject;
 
 }


### PR DESCRIPTION
# Description
When a data object or page is deleted from the CMS, a job is created (via the [onAfterDelete](https://github.com/silverstripe/silverstripe-search-service/blob/3/src/Extensions/SearchServiceExtension.php#L131-L138) method defined in the SearchServiceExtension) that should remove this item from the search index.

However, in the case of un-unversioned DataObjects this results in a broken job. This is because the unserialize method expects the DataObject to still exist but by then it has been deleted and no traces of it remain.

With this fix, we remove the need for the data object to exist by setting the 'identifier' and the ClassName on the DataObjectDocument when it is initiated. We then use these as a fallback when no DataObject is available.


## Screenshot with fix

<img width="1577" alt="Screenshot 2024-04-19 at 5 27 59 PM" src="https://github.com/silverstripeltd/silverstripe-search-service/assets/21965646/2f180806-eadf-4076-b4b9-83e86bf76d27">
