### PR TITLE
fix creation of dynamic property deprecated in php >= 8.2

### DIFF
--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -24,7 +24,7 @@ class DataObjectFetcher implements DocumentFetcherInterface
 
     private ?string $dataObjectClass = null;
 
-    public DocumentFetchCreatorRegistry $Register;
+    public DocumentFetchCreatorRegistry $Registry;
 
     private static array $dependencies = [
         'Configuration' => '%$' . IndexConfiguration::class,

--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -14,6 +14,7 @@ use SilverStripe\SearchService\Service\DocumentFetchCreatorRegistry;
 use SilverStripe\SearchService\Service\IndexConfiguration;
 use SilverStripe\SearchService\Service\Traits\ConfigurationAware;
 
+#[\AllowDynamicProperties]
 class DataObjectFetcher implements DocumentFetcherInterface
 {
 
@@ -23,8 +24,6 @@ class DataObjectFetcher implements DocumentFetcherInterface
     use ConfigurationAware;
 
     private ?string $dataObjectClass = null;
-
-    public DocumentFetchCreatorRegistry $Registry;
 
     private static array $dependencies = [
         'Configuration' => '%$' . IndexConfiguration::class,

--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -24,6 +24,8 @@ class DataObjectFetcher implements DocumentFetcherInterface
 
     private ?string $dataObjectClass = null;
 
+    public DocumentFetchCreatorRegistry $Register;
+
     private static array $dependencies = [
         'Configuration' => '%$' . IndexConfiguration::class,
         'Registry' => '%$' . DocumentFetchCreatorRegistry::class,


### PR DESCRIPTION
I have found the error when run `composer dev-build` it says "_Deprecated: Creation of dynamic property_" this just introduced in php version 8.2 or greater than [PHP 8.2 Ref](https://php.watch/versions/8.2/dynamic-properties-deprecated).

