### PR TITLE
DRAFT Allows indexing to continue if an index error occurs, and add log.

### DIFF
--- a/src/Admin/SearchAdmin.php
+++ b/src/Admin/SearchAdmin.php
@@ -206,6 +206,11 @@ class SearchAdmin extends LeftAndMain implements PermissionProvider
                     $query->where('ShowInSearch = 1');
                 }
 
+                // where appropriate, make sure we only show database total for this index
+                if ($class::singleton()->hasField('Subsite')) {
+                    $query->where(sprintf('SubsiteID = %s', $index));
+                }
+
                 $this->extend('updateQuery', $query, $data);
                 $localCount += $query->count();
             }

--- a/src/Admin/SearchAdmin.php
+++ b/src/Admin/SearchAdmin.php
@@ -208,7 +208,7 @@ class SearchAdmin extends LeftAndMain implements PermissionProvider
 
                 // where appropriate, make sure we only show database total for this index
                 if ($class::singleton()->hasField('Subsite')) {
-                    $query->where(sprintf('SubsiteID = %s', $index));
+                    $query->where(sprintf('SubsiteID = %s', $data['subsite_id']));
                 }
 
                 $this->extend('updateQuery', $query, $data);

--- a/src/Service/EnterpriseSearch/EnterpriseSearchService.php
+++ b/src/Service/EnterpriseSearch/EnterpriseSearchService.php
@@ -532,7 +532,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
         }
 
         foreach ($responseBody as $key => $response) {
-            if (!$response['errors']) {
+            if (!isset($response['errors']) || sizeof($response['errors']) === 0) {
                 continue;
             }
 

--- a/src/Service/Indexer.php
+++ b/src/Service/Indexer.php
@@ -110,7 +110,12 @@ class Indexer
             }
         }
 
-        if ($this->getIndexService()->hasIndexingErrors) {
+        // Check if we can determine errors were encountered during indexing
+        // and log warning if so.
+        if (
+            property_exists($this->getIndexService(), 'hasIndexingErrors')
+            && $this->getIndexService()->hasIndexingErrors
+        ) {
             Injector::inst()->get(LoggerInterface::class)->warning(
                 '[SEARCH SERVICE] Indexed with errors'
             );

--- a/src/Service/Indexer.php
+++ b/src/Service/Indexer.php
@@ -3,8 +3,10 @@
 namespace SilverStripe\SearchService\Service;
 
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentAddHandler;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
@@ -106,6 +108,12 @@ class Indexer
                     }
                 }
             }
+        }
+
+        if ($this->getIndexService()->hasIndexingErrors) {
+            Injector::inst()->get(LoggerInterface::class)->warning(
+                '[SEARCH SERVICE] Indexed with errors'
+            );
         }
 
         $this->chunks = $remainingChildren;

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -598,6 +598,11 @@ class DataObjectDocumentTest extends SearchServiceTest
         $mock->expects($this->exactly(2))
             ->method('markIndexed');
 
+        $dataObject = DataObjectFakeVersioned::create(['Title' => 'Document']);
+        $dataObject->publishSingle();
+
+        $mock->setDataObject($dataObject);
+
         $mock->onAddToSearchIndexes(DocumentAddHandler::BEFORE_ADD);
         $mock->onAddToSearchIndexes(DocumentAddHandler::AFTER_ADD);
         $mock->onRemoveFromSearchIndexes(DocumentRemoveHandler::BEFORE_REMOVE);


### PR DESCRIPTION
These changes allow indexing to continue even when an individual document might fail to index and return an error. In this  case, here we want the error to be clearly logged but the index process to continue.